### PR TITLE
fix(ffmpeg): remove -shortest and align audio duration to prevent dropped frames

### DIFF
--- a/src/ffmpeg.py
+++ b/src/ffmpeg.py
@@ -298,6 +298,9 @@ def start_encoder(
 
 
 def final_mux(temp_video: Path, source: Path, output: Path, container: str) -> None:
+    temp_probe = probe_video(temp_video)
+    duration = temp_probe.get("duration", 0.0)
+    input_args = ["-t", str(duration)] if duration > 0 else []
     if container == "MKV":
         maps = ["-map", "0:v:0", "-map", "1:a?", "-map", "1:s?"]
         streams = ["-c:v", "copy", "-c:a", "copy", "-c:s", "copy"]
@@ -321,6 +324,7 @@ def final_mux(temp_video: Path, source: Path, output: Path, container: str) -> N
         "-y",
         "-i",
         str(temp_video),
+        *input_args,
         "-i",
         str(source),
         *maps,
@@ -329,7 +333,6 @@ def final_mux(temp_video: Path, source: Path, output: Path, container: str) -> N
         "-map_chapters",
         "1",
         *streams,
-        "-shortest",
         str(output),
     ]
     result = subprocess.run(


### PR DESCRIPTION
## Description
Fixes an issue where video processing fails at the final verification step with an error like:
`RuntimeError: Output verification found X frames instead of Y.`

### Root Cause
In `src/ffmpeg.py`, `final_mux` previously passed the `-shortest` flag to FFmpeg when combining the processed video stream with the source audio/metadata. 

In many common video files (e.g. ComfyUI outputs, web MP4s, AAC audio), the audio track duration can be slightly shorter than the video track by a fraction of a frame (e.g., audio is 15.075s while video is 15.083s for 362 frames at 24fps). Because `-shortest` was enabled, FFmpeg would terminate encoding upon reaching the end of the audio stream, discarding the final video frame(s). This caused output frame count verification (`verified["frames"] != delivered`) to fail.

### Changes Made
- Removed `-shortest` from the `final_mux` FFmpeg command.
- Probed `temp_video` duration and passed `-t <duration>` to the source input (`-i <source>`), ensuring audio is cleanly trimmed to the processed video's duration without cutting off any rendered video frames.

### Verification
- Verified 1-frame preview rendering (1 frame generated and verified).
- Verified timed preview rendering (5.0s preview, 120 frames generated and verified).
- Verified full video render with audio discrepancy (362 frames generated and 100% verified).