### PR TITLE
Image comparison initial and aligning Preview to Upload for future comparison changes.

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ except Exception:
 
 import gradio as gr
 
+from src.compare.ui import bind_comparison_events, build_compare_tab
 from src.core.paths import LOGS, OUTPUTS
 from src.core.runtime import prepare_runtime
 from src.core.terminal import init_console
@@ -117,17 +118,22 @@ def build_app() -> gr.Blocks:
             "[GitHub](https://github.com/Merserk/dlss5-visual-enhancer)",
             elem_id="app-title",
         )
-        with gr.Tabs(selected="image"):
+        with gr.Tabs(selected="image") as tabs:
             with gr.Tab("Image", id="image"):
                 image_tab = build_image_tab(settings)
             with gr.Tab("Video", id="video"):
                 video_tab = build_video_tab(settings)
             with gr.Tab("Frame Interpolation", id="frame-interpolation"):
                 frame_tab = build_frame_interpolation_tab(settings)
+            with gr.Tab("Comparison", id="compare"):
+                compare_tab = build_compare_tab()
             with gr.Tab("Settings", id="settings"):
                 settings_tab = build_settings_tab(settings, ai_gpu_choices, video_gpu_choices)
 
         bind_settings_events(settings_tab, image_tab, video_tab, frame_tab)
+        # Video and Frame Interpolation aren't wired into Comparison yet (they need a synced
+        # player, not the image before/after slider) — that's a later phase.
+        bind_comparison_events(compare_tab, tabs, image_tab=image_tab)
     return demo
 
 

--- a/src/compare/models.py
+++ b/src/compare/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class ComparisonItem:
+    """One image that can be picked as a reference or candidate in the Comparison tab.
+
+    `label` is what shows up in the dropdowns (e.g. "Input: cat.png" or
+    "Output: cat_DLSS5.png"); `path` is the real file on disk. For sent-from-Image-tab
+    items this is always the full-resolution file, never a UI thumbnail.
+    """
+
+    label: str
+    path: str
+
+
+@dataclass(slots=True)
+class DiffMetrics:
+    """Numeric results of comparing two images. Purely computational — no display
+    formatting or labels here; the UI layer turns this into rows for the user.
+    """
+
+    reference_size: tuple[int, int]
+    candidate_size: tuple[int, int]
+    compared_size: tuple[int, int]
+    resampled: bool
+    mean_abs_error: float
+    root_mean_square_error: float
+    changed_pixels_pct: float
+    max_channel_delta: int

--- a/src/compare/processor.py
+++ b/src/compare/processor.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+from PIL import Image
+
+from ..image.decoder import decode_image
+from .models import DiffMetrics
+
+# A pixel counts as "changed" once any channel moves more than this many levels
+# (out of 255). A hard 0 would flag ordinary lossy-codec rounding noise as change.
+CHANGED_PIXEL_THRESHOLD = 2
+
+
+def _load_rgb(path: str) -> Image.Image:
+    """Decode any image the app can produce or accept as input, as RGB.
+
+    Tries the app's own decoder first (handles RAW/HEIC/SVG/etc., the same path
+    used for uploads), then falls back to plain Pillow for anything it doesn't
+    recognize (this covers every rendered output format, which are always
+    plain raster files).
+    """
+    try:
+        decoded = decode_image(path)
+        return Image.fromarray(decoded.rgba, mode="RGBA").convert("RGB")
+    except Exception:
+        with Image.open(path) as handle:
+            return handle.convert("RGB")
+
+
+def compute_diff(reference_path: str, candidate_path: str, amplify: float = 4.0) -> tuple[Image.Image, DiffMetrics]:
+    """Compare two images pixel-for-pixel.
+
+    Only meaningful at 1:1 — if the candidate is a different resolution than the
+    reference (e.g. an upscaled DLSS output), it's resampled down/up to the
+    reference's size with Lanczos before diffing, purely so the arrays line up.
+    `metrics.resampled` tells the caller this happened so the UI can flag it;
+    the resulting numbers describe a like-for-like comparison at that resolution,
+    not a claim about the candidate's native detail.
+    """
+    reference = _load_rgb(reference_path)
+    candidate = _load_rgb(candidate_path)
+    candidate_size = candidate.size
+    resampled = candidate.size != reference.size
+    compared_candidate = (
+        candidate.resize(reference.size, Image.Resampling.LANCZOS) if resampled else candidate
+    )
+
+    ref_arr = np.asarray(reference, dtype=np.float32)
+    cand_arr = np.asarray(compared_candidate, dtype=np.float32)
+    delta = cand_arr - ref_arr
+    abs_delta = np.abs(delta)
+    per_pixel_max = abs_delta.max(axis=2)
+
+    metrics = DiffMetrics(
+        reference_size=reference.size,
+        candidate_size=candidate_size,
+        compared_size=reference.size,
+        resampled=resampled,
+        mean_abs_error=float(abs_delta.mean()),
+        root_mean_square_error=float(np.sqrt(np.mean(delta ** 2))),
+        changed_pixels_pct=float((per_pixel_max > CHANGED_PIXEL_THRESHOLD).mean() * 100.0),
+        max_channel_delta=int(per_pixel_max.max()) if per_pixel_max.size else 0,
+    )
+
+    amplified = np.clip(per_pixel_max * max(float(amplify), 0.1), 0, 255).astype(np.uint8)
+    diff_image = Image.fromarray(amplified, mode="L")
+    return diff_image, metrics

--- a/src/compare/ui.py
+++ b/src/compare/ui.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import gradio as gr
+
+from .models import ComparisonItem, DiffMetrics
+from .processor import compute_diff
+
+NO_SELECTION = "(none yet — send an image here from another tab)"
+
+
+def _choices(pool: list[ComparisonItem]) -> list[str]:
+    labels = [item.label for item in pool]
+    return labels or [NO_SELECTION]
+
+
+def _path_for(pool: list[ComparisonItem], label: str) -> str | None:
+    for item in pool:
+        if item.label == label:
+            return item.path
+    return None
+
+
+def _metrics_rows(
+    metrics: DiffMetrics, reference_label: str, candidate_label: str
+) -> list[list[str]]:
+    rows = [
+        ["Reference", f"{reference_label}  ({metrics.reference_size[0]}×{metrics.reference_size[1]})"],
+        ["Candidate", f"{candidate_label}  ({metrics.candidate_size[0]}×{metrics.candidate_size[1]})"],
+        ["Mean abs error", f"{metrics.mean_abs_error:.3f} / 255"],
+        ["RMSE", f"{metrics.root_mean_square_error:.3f} / 255"],
+        ["Changed pixels", f"{metrics.changed_pixels_pct:.2f}%"],
+        ["Max channel delta", f"{metrics.max_channel_delta} / 255"],
+    ]
+    if metrics.resampled:
+        rows.append(
+            [
+                "Note",
+                f"Candidate resampled to {metrics.compared_size[0]}×{metrics.compared_size[1]} to "
+                "match the reference before comparing — resolutions differed, so this is a "
+                "like-for-like check at that size, not a native-detail comparison.",
+            ]
+        )
+    return rows
+
+
+def refresh_comparison(
+    pool: list[ComparisonItem], reference_label: str, candidate_label: str, amplify: float
+):
+    reference_path = _path_for(pool, reference_label)
+    candidate_path = _path_for(pool, candidate_label)
+    if not reference_path or not candidate_path:
+        return None, [["Status", "Pick a reference and a candidate above to compare."]], None
+    try:
+        diff_image, metrics = compute_diff(reference_path, candidate_path, amplify=amplify)
+    except Exception as exc:
+        return None, [["Status", f"Couldn't compare those two: {exc}"]], None
+    return (
+        (reference_path, candidate_path),
+        _metrics_rows(metrics, reference_label, candidate_label),
+        diff_image,
+    )
+
+
+def swap_selection(reference_label: str, candidate_label: str):
+    return candidate_label, reference_label
+
+
+def receive_items(new_items: list[ComparisonItem]):
+    labels = [item.label for item in new_items]
+    default_reference = next((label for label in labels if label.startswith("Input: ")), None) or (
+        labels[0] if labels else NO_SELECTION
+    )
+    default_candidate = next((label for label in labels if label.startswith("Output: ")), None) or (
+        labels[-1] if labels else NO_SELECTION
+    )
+    return (
+        new_items,
+        gr.update(choices=labels or [NO_SELECTION], value=default_reference),
+        gr.update(choices=labels or [NO_SELECTION], value=default_candidate),
+        gr.Tabs(selected="compare"),
+    )
+
+
+@dataclass(slots=True)
+class CompareTab:
+    pool: object
+    reference: object
+    candidate: object
+    swap: object
+    diff_amplify: object
+    slider: object
+    metrics: object
+    diff_image: object
+
+
+def build_compare_tab() -> CompareTab:
+    gr.Markdown(
+        "Send an image here with the **Send to Comparison** button under a render's output "
+        "(Image tab for now). Pick any two of the images that came along with it — an input, "
+        "or any rendered output — to diff them against each other."
+    )
+    pool = gr.State([])
+    with gr.Row():
+        reference = gr.Dropdown(choices=[NO_SELECTION], value=NO_SELECTION, label="Reference (baseline)")
+        candidate = gr.Dropdown(choices=[NO_SELECTION], value=NO_SELECTION, label="Candidate")
+        swap = gr.Button("⇄ Swap", scale=0)
+    slider = gr.ImageSlider(type="filepath", label="Before / after", height=520)
+    with gr.Row():
+        with gr.Column(scale=1):
+            metrics = gr.Dataframe(
+                headers=["Metric", "Value"], datatype=["str", "str"], interactive=False,
+                label="Comparison metrics", wrap=True,
+            )
+        with gr.Column(scale=1):
+            diff_amplify = gr.Slider(
+                1, 16, value=4, step=1, label="Diff visualization amplify",
+                info="Brightens the difference view below so subtle changes are easier to see. Doesn't affect the metrics.",
+            )
+            diff_image = gr.Image(
+                type="pil", interactive=False, label="Difference (amplified, grayscale)", height=360,
+            )
+    return CompareTab(pool, reference, candidate, swap, diff_amplify, slider, metrics, diff_image)
+
+
+def bind_comparison_events(compare_tab: CompareTab, tabs, image_tab=None) -> None:
+    refresh_inputs = [compare_tab.pool, compare_tab.reference, compare_tab.candidate, compare_tab.diff_amplify]
+    refresh_outputs = [compare_tab.slider, compare_tab.metrics, compare_tab.diff_image]
+    # Decoding + diffing a large or RAW image takes real time, so these stay on the
+    # normal queue (unlike the trivial instant updates elsewhere in this file) rather
+    # than running with queue=False, which would block the app while it works.
+    refresh_kwargs = dict(show_progress="minimal")
+    compare_tab.reference.change(refresh_comparison, inputs=refresh_inputs, outputs=refresh_outputs, **refresh_kwargs)
+    compare_tab.candidate.change(refresh_comparison, inputs=refresh_inputs, outputs=refresh_outputs, **refresh_kwargs)
+    compare_tab.diff_amplify.release(refresh_comparison, inputs=refresh_inputs, outputs=refresh_outputs, **refresh_kwargs)
+    compare_tab.swap.click(
+        swap_selection, inputs=[compare_tab.reference, compare_tab.candidate],
+        outputs=[compare_tab.reference, compare_tab.candidate], queue=False,
+    )
+    if image_tab is not None:
+        image_tab.send_to_compare.click(
+            receive_items, inputs=image_tab.comparison_items,
+            outputs=[compare_tab.pool, compare_tab.reference, compare_tab.candidate, tabs],
+            queue=False,
+        )

--- a/src/frame_interpolation/ui.py
+++ b/src/frame_interpolation/ui.py
@@ -143,12 +143,15 @@ class FrameInterpolationTab:
 
 
 def build_frame_interpolation_tab(settings: UISettings) -> FrameInterpolationTab:
+    # The uploader lives in its own full-width row, above the input/output columns,
+    # so both preview panes are the first element in their column and line up
+    # vertically regardless of how many files are queued in the uploader.
+    sources = gr.File(
+        label="Input video(s)", file_count="multiple", file_types=["video"],
+        type="filepath", allow_reordering=True, elem_id="frame-interpolation-upload-list",
+    )
     with gr.Row():
         with gr.Column(scale=3):
-            sources = gr.File(
-                label="Input video(s)", file_count="multiple", file_types=["video"],
-                type="filepath", allow_reordering=True, elem_id="frame-interpolation-upload-list",
-            )
             input_preview = gr.Video(label="Input video preview", interactive=False, visible=False)
             with gr.Accordion("DLSS Frame Generation Settings", open=True):
                 with gr.Row():

--- a/src/image/ui.py
+++ b/src/image/ui.py
@@ -12,6 +12,7 @@ from ..core.naming import RENAME_MODES
 from ..core.runtime import DLSS_MODEL_PRESETS, NR_PRESETS, NR_STYLES, UPSCALING_MODES
 from ..settings.models import AUTOMATIC_MASK_CHOICES, UISettings, automatic_mask_choice, parse_automatic_mask
 from ..settings.storage import processing_gpu_settings
+from ..compare.models import ComparisonItem
 from .decoder import decode_image
 from .encoder import take_image_preview
 from .batch import convert_images
@@ -145,9 +146,12 @@ def render_image_batch(
         result = convert_images(input_paths, options, progress=report)
     except Exception as exc:
         traceback.print_exc()
-        return [], [], None, [], f"Failed: {exc}"
+        return [], [], None, [], f"Failed: {exc}", []
 
     gallery = []
+    comparison_items = [
+        ComparisonItem(f"Input: {Path(path).name}", path) for path in input_paths
+    ]
     for item in result.successes:
         preview = take_image_preview(item.output_path)
         if preview is None:
@@ -156,6 +160,8 @@ def render_image_batch(
                 preview.thumbnail((1600, 1200), Image.Resampling.LANCZOS)
                 preview = preview.copy()
         gallery.append((preview, Path(item.output_path).name))
+        # Full-resolution output path, not the thumbnail above — comparisons need the real file.
+        comparison_items.append(ComparisonItem(f"Output: {Path(item.output_path).name}", item.output_path))
     files = [item.output_path for item in result.successes]
     rows = [
         [Path(item.input_path).name, "Complete", Path(item.output_path).name, "; ".join(item.warnings)]
@@ -171,7 +177,7 @@ def render_image_batch(
     )
     if result.failures:
         status += f"\nFirst error: {result.failures[0].error}"
-    return gallery, files, result.zip_path, rows, status
+    return gallery, files, result.zip_path, rows, status, comparison_items
 
 @dataclass(slots=True)
 class ImageTab:
@@ -187,6 +193,8 @@ class ImageTab:
     stop: object
     reset: object
     output_gallery: object
+    send_to_compare: object
+    comparison_items: object
     output_files: object
     zip_download: object
     status: object
@@ -203,12 +211,15 @@ class ImageTab:
 
 def build_image_tab(settings: UISettings) -> ImageTab:
     upload_types = ["image", ".svg", ".heic", ".heif", *sorted(RAW_EXTENSIONS)]
+    # The uploader lives in its own full-width row, above the input/output columns,
+    # so both preview panes are the first element in their column and line up
+    # vertically regardless of how many files are queued in the uploader.
+    sources = gr.File(
+        label="Input image(s)", file_count="multiple", file_types=upload_types,
+        type="filepath", allow_reordering=True, elem_id="image-upload-list",
+    )
     with gr.Row():
         with gr.Column(scale=3):
-            sources = gr.File(
-                label="Input image(s)", file_count="multiple", file_types=upload_types,
-                type="filepath", allow_reordering=True, elem_id="image-upload-list",
-            )
             input_gallery = gr.Gallery(
                 label="Input preview", columns=3, height=520, object_fit="contain",
                 interactive=False, buttons=["fullscreen"], elem_id="image-input-preview",
@@ -245,6 +256,10 @@ def build_image_tab(settings: UISettings) -> ImageTab:
                 interactive=False, buttons=["download", "download_all", "fullscreen"],
                 elem_id="image-output-preview",
             )
+            # Holds the real (non-thumbnail) input/output paths from the last render,
+            # so "Send to Comparison" always hands off full-resolution files.
+            comparison_items = gr.State([])
+            send_to_compare = gr.Button("Send to Comparison")
             output_files = gr.File(
                 label="Rendered image files", file_count="multiple", interactive=False,
                 elem_id="image-output-list",
@@ -258,7 +273,8 @@ def build_image_tab(settings: UISettings) -> ImageTab:
             )
     tab = ImageTab(
         sources, input_gallery, neural, model_preset, output_format, quality, rename_mode,
-        custom_suffix, render, stop, reset, output_gallery, output_files, zip_download, status, results
+        custom_suffix, render, stop, reset, output_gallery, send_to_compare, comparison_items,
+        output_files, zip_download, status, results
     )
     bind_image_events(tab)
     return tab
@@ -274,7 +290,10 @@ def bind_image_events(tab: ImageTab) -> None:
     )
     tab.render.click(
         render_image_batch, inputs=tab.render_inputs,
-        outputs=[tab.output_gallery, tab.output_files, tab.zip_download, tab.results, tab.status],
+        outputs=[
+            tab.output_gallery, tab.output_files, tab.zip_download, tab.results, tab.status,
+            tab.comparison_items,
+        ],
         concurrency_limit=1, show_progress="full", show_progress_on=tab.output_gallery,
     )
     tab.stop.click(cancel_active_job, outputs=tab.status, queue=False)

--- a/src/video/ui.py
+++ b/src/video/ui.py
@@ -277,12 +277,15 @@ class VideoTab:
 
 
 def build_video_tab(settings: UISettings) -> VideoTab:
+    # The uploader lives in its own full-width row, above the input/output columns,
+    # so both preview panes are the first element in their column and line up
+    # vertically regardless of how many files are queued in the uploader.
+    sources = gr.File(
+        label="Input video(s)", file_count="multiple", file_types=["video"],
+        type="filepath", allow_reordering=True, elem_id="video-upload-list",
+    )
     with gr.Row():
         with gr.Column(scale=3):
-            sources = gr.File(
-                label="Input video(s)", file_count="multiple", file_types=["video"],
-                type="filepath", allow_reordering=True, elem_id="video-upload-list",
-            )
             input_preview = gr.Video(label="Input video preview", interactive=False, visible=False)
             with gr.Accordion("DLSS 5 Neural Rendering Settings", open=True):
                 neural = build_neural_controls(settings)


### PR DESCRIPTION
## Modified
- `app.py` — added a "Comparison" tab, wired to the Image tab.
- `src/image/ui.py` — uploader moved above the input/output columns (alignment
  fix); added a "Send to Comparison" button and the plumbing that hands a
  render's real (non-thumbnail) input/output paths to the Comparison tab.
- `src/video/ui.py`, `src/frame_interpolation/ui.py` — same uploader-alignment
  fix as the Image tab. Not touched otherwise yet.

## New
- `src/compare/__init__.py` — empty, just makes it a package.
- `src/compare/models.py` — `ComparisonItem` (a selectable image: label + path),
  `DiffMetrics` (the numeric comparison result).
- `src/compare/processor.py` — `compute_diff()`: decodes two images, resamples
  the candidate to the reference's resolution if they differ (and flags that
  it did), and returns MAE / RMSE / changed-pixel% / max channel delta plus an
  amplified grayscale difference image.
- `src/compare/ui.py` — the Comparison tab itself: reference/candidate
  dropdowns, a swap button, a before/after `ImageSlider`, the metrics table,
  and the diff-amplify slider + difference view.